### PR TITLE
[BUG] Fechando mas nao saindo

### DIFF
--- a/processHelper.js
+++ b/processHelper.js
@@ -21,7 +21,7 @@ const spawnProcess = (...args) => {
     }
 
     process.on('error', reject);
-    process.on('exit', (code) => {
+    process.on('close', (code) => {
       if (code === 0) return resolve(processOutput);
       return reject(processOutput);
     });


### PR DESCRIPTION
**Contexto:**

Identificamos que ao utilizar [spawn](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) o processo estava sendo fechado, antes do streaming de buffer terminar.

A correção foi trocar no `EventListener` do mesmo o evento de `exit` para `close` 

Link da [documentação](https://github.com/nodejs/node/blob/8a6b37bc51a353227b6711d3c1df12c2863e3302/doc/api/child_process.md#event-close)

