### PR TITLE
Processamento de requests por chunks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ FILES_PATH=__mocks__/fixtures/priv/markdown_templates/content
 ASSETS_PATH=__mocks/fixtures/assets/static
 
 COMMIT_ID=7044d626ad61a8011a0ee8ad78e16c89f3c781f7
+
+CHUNK_SIZE=50
+INTERVAL_BETWEEN_CHUNKS=1500

--- a/index.js
+++ b/index.js
@@ -1,11 +1,23 @@
 const core = require('@actions/core');
 const { processContent } = require('./src/main');
 
+const millisToMinutesAndSeconds = (millis) => {
+  const minutes = Math.floor(millis / 60000);
+  const seconds = ((millis % 60000) / 1000).toFixed(0);
+  return `${minutes}:${(seconds < 10 ? '0' : '')}${seconds}`;
+};
+
 async function run() {
   try {
     core.info('Tryhard Action Rolling');
 
+    const start = Date.parse(new Date());
+
     await processContent();
+
+    const finish = Date.parse(new Date());
+
+    core.info(`Total: ${millisToMinutesAndSeconds(finish - start)}`);
 
     core.info('A new version of chapter was created with success');
   } catch (error) {

--- a/src/service.js
+++ b/src/service.js
@@ -70,22 +70,22 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const createChapters = async (arrayOfChapters, arrayOfAssets, apiUrl, apiKey) => {
   const groupOfChapters = createChaptersChunk(arrayOfChapters);
 
-  console.log('groups: ', groupOfChapters.length);
+  console.log('Número de Grupos: ', groupOfChapters.length);
 
-  const result = await groupOfChapters.reduce((chain, chapters) => (
+  const result = await groupOfChapters.reduce((chain, chapters, index) => (
     chain.then(async (previousResults) => {
-      console.log('Start sending...');
+      console.log(`Iniciando envio grupo ${(index + 1)}...`);
       const responses = await Promise.all(chapters.map((chapter) =>
         createChapter(apiUrl, chapter, arrayOfAssets, apiKey).catch((e) => e.response)));
 
       await sleep(INTERVAL_BETWEEN_CHUNKS);
-      console.log('Finished sending');
+      console.log('Envio finalizado.');
 
       return [...responses, ...previousResults || []];
     })
   ), Promise.resolve());
 
-  console.log('Fineshed all');
+  console.log('::Todos os grupos de requests finalizados::');
 
   return handleChaptersResult(result);
 };


### PR DESCRIPTION
Visando não sobrecarregar o servidor com muito conteúdo enviado ao mesmo tempo, mudamos pra `chunks` de requests para que haja uma folga entre os grupos.

Por enquanto está como 1500ms de intervalo em chunks de tamanho 50. 

Nota: pensei em adicionar uma dependência com o lodash pra usar o `_.chunk` que tem nele, mas por agora deixei a implementação no código mesmo e nao adicionei o lodash. 

Aqui um print do terminal mostrando o log das requests: 

![Screen Shot 2021-01-25 at 09 28 29](https://user-images.githubusercontent.com/542597/105705961-b1e98d00-5eef-11eb-8d9a-318912989653.png)

Ele mostra a quantidade de grupos (chunks) que serão divididos os requests, baseado no total de arquivos extraídos pelo git (nesse caso enviei o conteúdo completo). E também mostra qual grupo iniciou o processamento, seu término e o início do próximo. E a mensagem final de que todos foram processados