### PR TITLE
Corrige leitura de resposta da api

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -121,13 +121,17 @@ describe('Action Execution', () => {
         results: [
           {
             data: {
-              chapter_id: 'c54f3049-965a-4634-ae16-6e4251ef7e3e',
+              data: {
+                chapter_id: 'c54f3049-965a-4634-ae16-6e4251ef7e3e',
+              },
             },
             status: 200,
           },
           {
             data: {
-              chapter_id: '94849e6f-0075-4970-a06a-ed821708490a',
+              data: {
+                chapter_id: '94849e6f-0075-4970-a06a-ed821708490a',
+              },
             },
             status: 200,
           },

--- a/__tests__/service.test.js
+++ b/__tests__/service.test.js
@@ -21,7 +21,9 @@ describe('Create Chapters', () => {
 
     const returnData = {
       data: {
-        chapter_id: 'c54f3049-965a-4634-ae16-6e4251ef7e3e',
+        data: {
+          chapter_id: 'fb61c068-609e-447d-92ba-b083bc2dcd20',
+        },
       },
       status: 200,
     };

--- a/src/service.js
+++ b/src/service.js
@@ -25,7 +25,7 @@ const handleChaptersResult = (createdChaptersResult) =>
     const newResultAccumulator = { ...resultAccumulator };
     if (currentResult.status === 200) {
       newResultAccumulator.results = [
-        ...newResultAccumulator.results, currentResult.data.chapter_id,
+        ...newResultAccumulator.results, currentResult.data.data.chapter_id,
       ];
       return newResultAccumulator;
     }


### PR DESCRIPTION
A resposta da api de criação de conteúdo foi trocada no backend e agora na leitura do serviço precisamos de envelopá-la dentro de `data`, caso contrários valores nulos sao enviados para a criação de versão. 