### PR TITLE
[LEARN-1606] Corrige o Content-Type dos arquivos enviados para o S3

### DIFF
--- a/__tests__/s3.test.js
+++ b/__tests__/s3.test.js
@@ -17,7 +17,7 @@ describe('S3 Client Actions', () => {
     const assetPath = '__mocks__/fixtures/assets/static/agile/scrum.png';
     const rawAssetBlob = readMockFile(assetPath);
 
-    const result = await s3Service.imageUpload(rawAssetBlob, assetPath, '.png');
+    const result = await s3Service.imageUpload(rawAssetBlob, assetPath, 'png');
 
     expect(typeof result).toBe('object');
     expect(result).toHaveProperty('Location', '__mocks__/fixtures/assets/static/agile/scrum-213c790c4129428a74486324d08e78e7.png');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4024,6 +4024,11 @@
         "picomatch": "^2.0.5"
       }
     },
+    "mime": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+    },
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "aws-sdk": "^2.808.0",
     "axios": "^0.21.0",
     "benchmark": "^2.1.4",
-    "dotenv": "^8.2.0"
+    "dotenv": "^8.2.0",
+    "mime": "^2.5.2"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.25.1",

--- a/src/s3.js
+++ b/src/s3.js
@@ -4,19 +4,29 @@ const fs = require('fs');
 const path = require('path');
 const logger = require('./logger');
 
+/**
+ * Extrai do caminho do arquivo a extensão.
+ * @param {string} filePath
+ * @returns {string}
+ */
+const extractFileExtension = (filePath) => {
+  const extension = path.extname(filePath);
+  return extension.slice(1);
+};
+
 const credentials = {
   accessKeyId: core.getInput('awsAccessKey') || process.env.AWS_ACCESS_KEY,
   secretAccessKey: core.getInput('awsSecret') || process.env.AWS_SECRET,
 };
 
-const imageUpload = (assetUrlHash, assetBlob, fileType) => {
+const imageUpload = (assetUrlHash, assetBlob, extension) => {
   const s3BucketClient = new AWS.S3(credentials);
 
   const params = {
     Bucket: core.getInput('bucketName') || process.env.BUCKET_NAME,
     Key: assetUrlHash,
     Body: assetBlob,
-    ContentType: `image/${fileType}`,
+    ContentType: `image/${extension}`,
   };
 
   return s3BucketClient.upload(params, {}).promise();
@@ -25,9 +35,9 @@ const imageUpload = (assetUrlHash, assetBlob, fileType) => {
 const uploadToBucket = async (assetUrlHash, assetPath) => {
   try {
     const assetBlob = fs.readFileSync(assetPath);
-    const fileType = path.extname(assetPath);
+    const extension = extractFileExtension(assetPath);
 
-    const { Location } = await imageUpload(assetUrlHash, assetBlob, fileType);
+    const { Location } = await imageUpload(assetUrlHash, assetBlob, extension);
 
     return Location;
   } catch (error) {


### PR DESCRIPTION
## O que foi feito?
Criei uma função para fazer a extração da extensão do caminho de um arquivo.

## Qual o resultado?
Isso conserta o erro no Content-Type das imagens ao fazer _upload_ para o s3.

Link do _card_ no JIRA:
https://trybe.atlassian.net/browse/LEARN-1606

Link da _thread_ no Slack:
https://betrybe.slack.com/archives/C0160E5M3A6/p1620827057091000